### PR TITLE
大佬，发现您的项目引入了com.fasterxml.jackson.core:jackson-databind@2.9.5组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.demo</groupId>
   <artifactId>jfinal_demo_for_maven</artifactId>
@@ -148,7 +148,7 @@
 	  <dependency>
 		  <groupId>com.fasterxml.jackson.core</groupId>
 		  <artifactId>jackson-databind</artifactId>
-		  <version>2.9.5</version>
+		  <version>2.9.10.8</version>
 	  </dependency>
 
 	  <!--Jackson是一款高性能的JSON处理器-->
@@ -180,7 +180,7 @@
 					<encoding>UTF-8</encoding>
 					<!-- java8 保留参数名编译参数 -->
 					<compilerArgument>-parameters</compilerArgument>
-					<compilerArguments><verbose /></compilerArguments>
+					<compilerArguments><verbose/></compilerArguments>
 				</configuration>
 			</plugin>
 			


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：FasterXML jackson-databind 代码问题漏洞
缺陷组件：com.fasterxml.jackson.core:jackson-databind@2.9.5
漏洞编号：CVE-2019-14540
漏洞描述：FasterXML Jackson是美国FasterXML公司的一款适用于Java的数据处理工具。jackson-databind是其中的一个具有数据绑定功能的组件。
FasterXML jackson-databind 2.9.10之前版本中存在代码问题漏洞。攻击者可利用该漏洞执行代码。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2019-37174
影响范围：[2.9.0, 2.9.10)
最小修复版本：2.9.10.8
缺陷组件引入路径：com.demo:jfinal_demo_for_maven@4.0->com.fasterxml.jackson.core:jackson-databind@2.9.5
```
另外我运行这个项目时，IDE的安全插件提示还有86个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p20587